### PR TITLE
Fix GraalVm native image build fail

### DIFF
--- a/ulid/src/commonMain/kotlin/ulid/internal/ULIDValue.kt
+++ b/ulid/src/commonMain/kotlin/ulid/internal/ULIDValue.kt
@@ -47,8 +47,4 @@ internal data class ULIDValue(
         buffer.write(leastSignificantBits, 8, 18)
         return buffer.concatToString()
     }
-
-    companion object {
-        private const val serialVersionUID = 1L
-    }
 }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no   
| BC breaks?        | no
| Related Issue     | Fix GraalVm native image build fail
| Need Doc update   | no

## Describe your change

```text:error_log
Build resources:
 - 26.40GB of memory (41.3% of 64.00GB system memory, determined at start)
 - 16 thread(s) (100.0% of 16 available processor(s), determined at start)
20:56:24,146 WARN  [org.hib.orm.deprecation] HHH90000025: MariaDBDialect does not need to be specified explicitly using 'hibernate.dialect' (remove the property setting and it will be selected by default)
20:56:37,071 WARN  [io.net.res.dns.DnsServerAddressStreamProviders] Can not find io.netty.resolver.dns.macos.MacOSDnsServerAddressStreamProvider in the classpath, fallback to system defaults. This may result in incorrect DNS resolutions on MacOS. Check whether you have a dependency on 'io.netty:netty-resolver-dns-native-macos'
[2/8] Performing analysis...  [******]                                                                  (31.6s @ 1.98GB)
   25,018 reachable types   (90.3% of   27,692 total)
   34,194 reachable fields  (62.8% of   54,474 total)
  122,415 reachable methods (55.5% of  220,465 total)
    7,775 types,   454 fields, and 5,505 methods registered for reflection
       61 types,    61 fields, and    55 methods registered for JNI access
        5 native libraries: -framework CoreServices, -framework Foundation, dl, pthread, z
[3/8] Building universe...                                                                               (4.3s @ 2.58GB)
[4/8] Parsing methods...      [**]                                                                       (2.8s @ 1.52GB)
[5/8] Inlining methods...     [****]                                                                     (1.4s @ 2.12GB)
[6/8] Compiling methods...    [****]                                                                    (18.7s @ 3.12GB)
[7/8] Layouting methods...    [***]                                                                      (5.3s @ 2.26GB)

[8/8] Creating image...       [**]                                                                       (0.0s @ 1.71GB)
------------------------------------------------------------------------------------------------------------------------
                        6.9s (8.8% of total time) in 143 GCs | Peak RSS: 6.91GB | CPU load: 9.89
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /Users/xxx/workspace/code-with-quarkus-kotlin/build/code-with-quarkus-kotlin-1.0.0-SNAPSHOT-native-image-source-jar/svm_err_b_20240214T205730.831_pid15765.md (build_info)
========================================================================================================================
Failed generating 'code-with-quarkus-kotlin-1.0.0-SNAPSHOT-runner' after 1m 18s.

The build process encountered an unexpected error:

com.oracle.svm.core.util.VMError$HostedError: com.oracle.svm.core.util.UserError$UserException: Image heap writing found a class not seen during static analysis. Did a static field or an object referenced from a static field change during native image generation? For example, a lazily initialized cache could have been initialized during image generation, in which case you need to force eager initialization of the cache before static analysis or reset the cache using a field value recomputation.
    class: ulid.internal.ULIDValue$Companion
  reachable through:
    object: [Ljava.lang.Class;@31299ff6  of class: java.lang.Class[]
    object: com.oracle.svm.core.code.ImageCodeInfo@689bab56  of class: com.oracle.svm.core.code.ImageCodeInfo
    root: com.oracle.svm.core.code.ImageCodeInfo.prepareCodeInfo()

        at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.VMError.shouldNotReachHere(VMError.java:82)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:720)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:550)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:539)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:721)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.start(NativeImageGeneratorRunner.java:143)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:98)
Caused by: com.oracle.svm.core.util.UserError$UserException: Image heap writing found a class not seen during static analysis. Did a static field or an object referenced from a static field change during native image generation? For example, a lazily initialized cache could have been initialized during image generation, in which case you need to force eager initialization of the cache before static analysis or reset the cache using a field value recomputation.
    class: ulid.internal.ULIDValue$Companion
  reachable through:
    object: [Ljava.lang.Class;@31299ff6  of class: java.lang.Class[]
    object: com.oracle.svm.core.code.ImageCodeInfo@689bab56  of class: com.oracle.svm.core.code.ImageCodeInfo
    root: com.oracle.svm.core.code.ImageCodeInfo.prepareCodeInfo()

        at org.graalvm.nativeimage.builder/com.oracle.svm.core.util.UserError.abort(UserError.java:73)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.NativeImageHeap.reportIllegalType(NativeImageHeap.java:592)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.NativeImageHeap.addConstant(NativeImageHeap.java:303)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.NativeImageHeap.processAddObjectWorklist(NativeImageHeap.java:705)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.image.NativeImageHeap.addTrailingObjects(NativeImageHeap.java:202)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.buildNativeImageHeap(NativeImageGenerator.java:760)
        at org.graalvm.nativeimage.builder/com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:697)
        ... 5 more

> Task :quarkusAppPartsBuild FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':quarkusAppPartsBuild'.
> There was a failure while executing work items
   > A failure occurred while executing io.quarkus.gradle.tasks.worker.BuildWorker
      > io.quarkus.builder.BuildException: Build failure: Build failed due to errors
                [error]: Build step io.quarkus.deployment.pkg.steps.NativeImageBuildStep#build threw an exception: io.quarkus.deployment.pkg.steps.NativeImageBuildStep$ImageGenerationFailureException: Image generation failed. Exit code: 1
                at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.imageGenerationFailed(NativeImageBuildStep.java:468)
                at io.quarkus.deployment.pkg.steps.NativeImageBuildStep.build(NativeImageBuildStep.java:258)
                at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
                at java.base/java.lang.reflect.Method.invoke(Method.java:580)
                at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:849)
                at io.quarkus.builder.BuildContext.run(BuildContext.java:256)
                at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
                at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
                at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
                at java.base/java.lang.Thread.run(Thread.java:1583)
                at org.jboss.threads.JBossThread.run(JBossThread.java:501)
```

## What problem is this fixing?
Fix GraalVm native image build fail on step 8.
Maybe it is due to GraalVm compatibility is not so good for kotlin companion object.