### PR TITLE
fix: 1. use unsigned comparison in `compareTo` 2. add JVM `toUUID()`/`fromUUID()` extensions

### DIFF
--- a/ulid/api/ulid.api
+++ b/ulid/api/ulid.api
@@ -1,0 +1,67 @@
+public abstract interface class ulid/ULID : java/lang/Comparable {
+	public static final field Companion Lulid/ULID$Companion;
+	public abstract fun getLeastSignificantBits ()J
+	public abstract fun getMostSignificantBits ()J
+	public abstract fun getTimestamp ()J
+	public abstract fun increment ()Lulid/ULID;
+	public abstract fun toBytes ()[B
+}
+
+public final class ulid/ULID$Companion : ulid/ULID$Factory {
+	public final fun Factory (Lkotlin/random/Random;)Lulid/ULID$Factory;
+	public static synthetic fun Factory$default (Lulid/ULID$Companion;Lkotlin/random/Random;ILjava/lang/Object;)Lulid/ULID$Factory;
+	public final fun Monotonic (Lulid/ULID$Factory;)Lulid/ULID$Monotonic;
+	public static synthetic fun Monotonic$default (Lulid/ULID$Companion;Lulid/ULID$Factory;ILjava/lang/Object;)Lulid/ULID$Monotonic;
+	public fun fromBytes ([B)Lulid/ULID;
+	public fun nextULID (J)Lulid/ULID;
+	public fun parseULID (Ljava/lang/String;)Lulid/ULID;
+	public fun randomULID (J)Ljava/lang/String;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class ulid/ULID$Factory {
+	public abstract fun fromBytes ([B)Lulid/ULID;
+	public abstract fun nextULID (J)Lulid/ULID;
+	public static synthetic fun nextULID$default (Lulid/ULID$Factory;JILjava/lang/Object;)Lulid/ULID;
+	public abstract fun parseULID (Ljava/lang/String;)Lulid/ULID;
+	public abstract fun randomULID (J)Ljava/lang/String;
+	public static synthetic fun randomULID$default (Lulid/ULID$Factory;JILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class ulid/ULID$Factory$DefaultImpls {
+	public static synthetic fun nextULID$default (Lulid/ULID$Factory;JILjava/lang/Object;)Lulid/ULID;
+	public static synthetic fun randomULID$default (Lulid/ULID$Factory;JILjava/lang/Object;)Ljava/lang/String;
+}
+
+public abstract interface class ulid/ULID$Monotonic {
+	public static final field Companion Lulid/ULID$Monotonic$Companion;
+	public abstract fun nextULID (Lulid/ULID;J)Lulid/ULID;
+	public static synthetic fun nextULID$default (Lulid/ULID$Monotonic;Lulid/ULID;JILjava/lang/Object;)Lulid/ULID;
+	public abstract fun nextULIDStrict (Lulid/ULID;J)Lulid/ULID;
+	public static synthetic fun nextULIDStrict$default (Lulid/ULID$Monotonic;Lulid/ULID;JILjava/lang/Object;)Lulid/ULID;
+}
+
+public final class ulid/ULID$Monotonic$Companion : ulid/ULID$Monotonic {
+	public fun nextULID (Lulid/ULID;J)Lulid/ULID;
+	public fun nextULIDStrict (Lulid/ULID;J)Lulid/ULID;
+}
+
+public final class ulid/ULID$Monotonic$DefaultImpls {
+	public static synthetic fun nextULID$default (Lulid/ULID$Monotonic;Lulid/ULID;JILjava/lang/Object;)Lulid/ULID;
+	public static synthetic fun nextULIDStrict$default (Lulid/ULID$Monotonic;Lulid/ULID;JILjava/lang/Object;)Lulid/ULID;
+}
+
+public final class ulid/UUIDKt {
+	public static final fun fromUUID (Lulid/ULID$Companion;Ljava/util/UUID;)Lulid/ULID;
+	public static final fun toUUID (Lulid/ULID;)Ljava/util/UUID;
+}
+
+public final class ulid/internal/ULIDAsStringSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Lulid/internal/ULIDAsStringSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lulid/ULID;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lulid/ULID;)V
+}
+

--- a/ulid/src/commonMain/kotlin/ulid/ULID.kt
+++ b/ulid/src/commonMain/kotlin/ulid/ULID.kt
@@ -37,6 +37,11 @@ public interface ULID : Comparable<ULID> {
      */
     public fun toBytes(): ByteArray
 
+    /**
+     * Increment the random part of this [ULID] by 1.
+     *
+     * If the 80-bit random part overflows, the random part is reset to zero while the timestamp remains unchanged.
+     */
     public fun increment(): ULID
 
     /**

--- a/ulid/src/commonMain/kotlin/ulid/internal/ULIDValue.kt
+++ b/ulid/src/commonMain/kotlin/ulid/internal/ULIDValue.kt
@@ -30,17 +30,15 @@ internal data class ULIDValue(
     }
 
     override fun compareTo(other: ULID): Int {
-        return if (mostSignificantBits < other.mostSignificantBits) -1
-        else if (mostSignificantBits > other.mostSignificantBits) 1
-        else if (leastSignificantBits < other.leastSignificantBits) -1
-        else if (leastSignificantBits > other.leastSignificantBits) 1
-        else 0
+        val msbCmp = mostSignificantBits.toULong().compareTo(other.mostSignificantBits.toULong())
+        if (msbCmp != 0) return msbCmp
+        return leastSignificantBits.toULong().compareTo(other.leastSignificantBits.toULong())
     }
 
     override fun toString(): String {
         val buffer = CharArray(26)
         buffer.write(timestamp, 10, 0)
-        var value = mostSignificantBits and Mask16Bits shl 24
+        var value = (mostSignificantBits and Mask16Bits) shl 24
         val interim = leastSignificantBits ushr 40
         value = value or interim
         buffer.write(value, 8, 10)

--- a/ulid/src/commonTest/kotlin/ulid/TestULID.kt
+++ b/ulid/src/commonTest/kotlin/ulid/TestULID.kt
@@ -6,6 +6,8 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TestULID {
 
@@ -71,6 +73,83 @@ class TestULID {
                     }
                 }
             }
+        }
+    }
+
+    @Test
+    fun test_comparable_unsigned_edge_cases() {
+        // LSB sign bit: 0x8000000000000000 (Long.MIN_VALUE) should be > 0x7FFFFFFFFFFFFFFF (Long.MAX_VALUE) unsigned
+        val a = ULIDValue(100L, Long.MAX_VALUE)
+        val b = ULIDValue(100L, Long.MIN_VALUE)
+        assertTrue(b > a, "LSB with sign bit set should be greater (unsigned)")
+        assertTrue(a < b, "LSB without sign bit should be less (unsigned)")
+
+        // MSB sign bit
+        val c = ULIDValue(Long.MAX_VALUE, 0L)
+        val d = ULIDValue(Long.MIN_VALUE, 0L)
+        assertTrue(d > c, "MSB with sign bit set should be greater (unsigned)")
+        assertTrue(c < d, "MSB without sign bit should be less (unsigned)")
+
+        // Both bits set
+        val e = ULIDValue(Long.MIN_VALUE, Long.MAX_VALUE)
+        val f = ULIDValue(Long.MIN_VALUE, Long.MIN_VALUE)
+        assertTrue(f > e, "Same MSB, LSB with sign bit should be greater (unsigned)")
+
+        // All bits set should be the maximum
+        val max = ULIDValue(AllBitsSet, AllBitsSet)
+        val almostMax = ULIDValue(AllBitsSet, AllBitsSet - 1)
+        assertTrue(max > almostMax)
+    }
+
+    @Test
+    fun test_increment() {
+        // Basic increment
+        val a = ULIDValue(0L, 0L)
+        val b = a.increment()
+        assertEquals(ULIDValue(0L, 1L), b)
+
+        // Increment at LSB boundary (Long.MAX_VALUE -> Long.MIN_VALUE in signed, but correct unsigned continuation)
+        val c = ULIDValue(0L, Long.MAX_VALUE)
+        val d = c.increment()
+        assertEquals(ULIDValue(0L, Long.MIN_VALUE), d)
+        assertTrue(d > c, "Incremented value should be greater (unsigned)")
+
+        // Increment at LSB = -1 (all bits set) -> carries to MSB
+        val e = ULIDValue(0L, -0x1L)
+        val f = e.increment()
+        assertEquals(ULIDValue(1L, 0L), f)
+
+        // Overflow: when 80-bit random part is maxed out, resets to zero random
+        val g = ULIDValue(0xFFFFL, -0x1L)
+        val h = g.increment()
+        assertEquals(ULIDValue(0L, 0L), h)
+    }
+
+    @Test
+    fun test_nextULIDStrict_with_lsb_max_value() {
+        // When LSB = Long.MAX_VALUE and timestamp matches, increment gives LSB = Long.MIN_VALUE
+        // which should be considered greater (unsigned), so nextULIDStrict should return non-null
+        val previous = ULIDValue(0L, Long.MAX_VALUE)
+        val result = ULID.Monotonic.nextULIDStrict(previous, 0)
+        assertEquals(ULIDValue(0L, Long.MIN_VALUE), result)
+        assertTrue(result!! > previous, "Incremented value should be greater (unsigned)")
+    }
+
+    @Test
+    fun test_roundtrip_crockford_encode_decode() {
+        // Verify parse(encode(x)) == x for various values
+        val values = listOf(
+            ULIDValue(0L, 0L),
+            ULIDValue(AllBitsSet, AllBitsSet),
+            ULIDValue(PatternMostSignificantBits, PatternLeastSignificantBits),
+            ULIDValue(Long.MAX_VALUE, Long.MIN_VALUE),
+            ULIDValue(Long.MIN_VALUE, Long.MAX_VALUE),
+        )
+
+        for (original in values) {
+            val encoded = original.toString()
+            val decoded = ULID.parseULID(encoded)
+            assertEquals(original, decoded, "Round-trip failed for $original")
         }
     }
 }

--- a/ulid/src/jvmMain/kotlin/ulid/UUID.kt
+++ b/ulid/src/jvmMain/kotlin/ulid/UUID.kt
@@ -1,0 +1,20 @@
+package ulid
+
+import java.util.UUID
+
+/**
+ * Convert this [ULID] to a [UUID].
+ */
+public fun ULID.toUUID(): UUID = UUID(mostSignificantBits, leastSignificantBits)
+
+/**
+ * Create a [ULID] from a [UUID].
+ */
+public fun ULID.Companion.fromUUID(uuid: UUID): ULID = ULID.fromBytes(
+    ByteArray(16).also { bytes ->
+        val msb = uuid.mostSignificantBits
+        val lsb = uuid.leastSignificantBits
+        for (i in 0..7) bytes[i] = (msb shr ((7 - i) * 8) and 0xFF).toByte()
+        for (i in 8..15) bytes[i] = (lsb shr ((15 - i) * 8) and 0xFF).toByte()
+    }
+)

--- a/ulid/src/jvmTest/kotlin/ulid/TestUUID.kt
+++ b/ulid/src/jvmTest/kotlin/ulid/TestUUID.kt
@@ -1,0 +1,40 @@
+package ulid
+
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestUUID {
+
+    @Test
+    fun `test ULID to UUID round-trip`() {
+        val ulid = ULID.nextULID()
+        val uuid = ulid.toUUID()
+        val roundTripped = ULID.fromUUID(uuid)
+        assertEquals(ulid, roundTripped)
+    }
+
+    @Test
+    fun `test UUID to ULID round-trip`() {
+        val uuid = UUID.randomUUID()
+        val ulid = ULID.fromUUID(uuid)
+        val roundTripped = ulid.toUUID()
+        assertEquals(uuid, roundTripped)
+    }
+
+    @Test
+    fun `test toUUID preserves bits`() {
+        val ulid = ULID.nextULID()
+        val uuid = ulid.toUUID()
+        assertEquals(ulid.mostSignificantBits, uuid.mostSignificantBits)
+        assertEquals(ulid.leastSignificantBits, uuid.leastSignificantBits)
+    }
+
+    @Test
+    fun `test fromUUID preserves bits`() {
+        val uuid = UUID.randomUUID()
+        val ulid = ULID.fromUUID(uuid)
+        assertEquals(uuid.mostSignificantBits, ulid.mostSignificantBits)
+        assertEquals(uuid.leastSignificantBits, ulid.leastSignificantBits)
+    }
+}


### PR DESCRIPTION
1. Fix signed `Long` comparison bug in `ULID.compareTo` that caused incorrect ordering when MSB/LSB had the sign bit set (~50% of random ULIDs). 
2. Add JVM `toUUID()`/`fromUUID()` extensions
3. KDoc for `increment()`
4. Clarify `toString()` operator precedence